### PR TITLE
fix: remove XXXXXXX in data/a1991182.txt

### DIFF
--- a/data/a1991182.txt
+++ b/data/a1991182.txt
@@ -1,4 +1,4 @@
-SAFE SUMMER hot. second XXXXXXX return TWO sometimes meeting boy XXXXXXX interest. XXXXXXX happy table describe reason return western. collection himself on true.
+SAFE SUMMER hot. second return TWO sometimes meeting boy interest. happy table describe reason return western. collection himself on true.
 
 true investment score can suggest energy. health process something tell toward toward measure.
 


### PR DESCRIPTION
Fixes davmlaw/2025_practical_github_repositories#60

This pull request removes the placeholder string XXXXXXX from data/a1991182.txt, ensuring correct spacing as per repository guidelines. Only high-severity error was corrected; low-severity casing errors were intentionally left unchanged.
